### PR TITLE
Remove tsv and sqlite download link from "data analysis" table

### DIFF
--- a/mogi/tables/tables_datasets.py
+++ b/mogi/tables/tables_datasets.py
@@ -14,5 +14,6 @@ class ResultsDataTable(ColumnShiftTable):
 
         model = models_datasets.Dataset
         # add class="paleblue" to <table> tag
+        exclude = ('sqlite', 'tsv')
 
         attrs = {"class": TABLE_CLASS}


### PR DESCRIPTION
 tsv and sqlite download link for each dataset from Galaxy possible to download directly by user on production

Due to permissions of accessing data.